### PR TITLE
Added fact support for Ubuntu

### DIFF
--- a/lib/facter/megaraid.rb
+++ b/lib/facter/megaraid.rb
@@ -4,12 +4,10 @@
 # Author: Matteo Cerutti <matteo.cerutti@hotmail.co.uk>
 #
 
-if File.exists?('/sbin/lspci')
+if Facter::Core::Execution.which('lspci')
   Facter.add(:has_megaraid) do
-    %x[/sbin/lspci | grep -q 'MegaRAID']
-    has_megaraid = $?.success?
     setcode do
-      has_megaraid
+      Facter::Core::Execution.execute('lspci').include? 'MegaRAID'
     end
   end
 end


### PR DESCRIPTION
On Ubuntu (verified on 16.04) lspci is located in /usr/bin/lspci